### PR TITLE
Fix for unpacking KR B85 - name array is out of order

### DIFF
--- a/GothosDC/DataCenter.cs
+++ b/GothosDC/DataCenter.cs
@@ -64,7 +64,10 @@ namespace GothosDC
         public DataCenter(DataCenterRaw lowLevel)
         {
             _strings = lowLevel.Strings.CollectionToDictionary(x => x.Key, x => x.Value);
-            _names = new[] { "__placeholder__" }.Concat(lowLevel.Names.Select(x => x.Value)).ToArray();
+            
+            var nameMapping = new SegmentAddressDictionary<string>(lowLevel.Names, lowLevel.Names.Last().Key);
+            _names = new[] { "__placeholder__" }.Concat(lowLevel.NameIds.Select(x => nameMapping[x])).ToArray();
+            
             _values = new SegmentAddressDictionary<DataCenterValueRaw>(lowLevel.Values, lowLevel.Values.Last().Key);
             _elements = new SegmentAddressDictionary<DataCenterElementRaw>(lowLevel.Elements, lowLevel.Elements.Last().Key);
             Revision = lowLevel.Revision;


### PR DESCRIPTION
Newest KR dc B85 doesnt unpack, because the NameIds array isn't ordered as usual - therefore assumption made on changed line screws up the names of basically everything.